### PR TITLE
JenkinFile Edit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,8 @@ npm-debug.*
 yarn-debug.*
 yarn-error.*
 
+Devops/esp32/secrets.h
+
 # macOS
 .DS_Store
 *.pem

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,6 +19,7 @@ pipeline {
         USER_ID = credentials('USER_ID')
         HOME = 'C:\\Users\\vivek'
         USERPROFILE = 'C:\\Users\\vivek'
+        PYTHON_DIR = 'C:\\Users\\vivek\\AppData\\Local\\Programs\\Python\\Python313'
     }
     stages {
         stage('Checkout') {
@@ -84,7 +85,7 @@ pipeline {
                         bat '''
                         set ENV_FILE_PATH=../.env
                         echo 📋 Checking compiled firmware...
-                        python upload_firmware.py binaries
+                        %PYTHON_DIR%\python.exe upload_firmware.py binaries
                         '''
                         
                         // Conditionally upload firmware if parameter is set
@@ -96,7 +97,7 @@ pipeline {
                             
                             bat """
                             set ENV_FILE_PATH=../.env
-                            python upload_firmware.py upload "../Devops/esp32/build/esp32.esp32.esp32wrover/Devops.ino.bin" ${params.FIRMWARE_VERSION} ${params.DEVICE_TYPE} ${params.IS_MANDATORY} ${forceFlag}
+                            %PYTHON_DIR%\python.exe upload_firmware.py upload "../Devops/esp32/build/esp32.esp32.esp32wrover/Devops.ino.bin" ${params.FIRMWARE_VERSION} ${params.DEVICE_TYPE} ${params.IS_MANDATORY} ${forceFlag}
                             """
                             
                             echo "✅ Firmware uploaded! Version: ${params.FIRMWARE_VERSION}, Device: ${params.DEVICE_TYPE}"


### PR DESCRIPTION
This pull request updates the Jenkins pipeline to use a specific Python installation for running firmware upload scripts, ensuring consistency and avoiding issues with ambiguous Python executables.

**Build environment configuration:**

* Added the `PYTHON_DIR` environment variable to specify the path to the desired Python installation (`C:\Users\vivek\AppData\Local\Programs\Python\Python313`).

**Script invocation updates:**

* Updated the firmware checking and upload steps to use the explicit Python executable path (`%PYTHON_DIR%\python.exe`) instead of the generic `python` command, ensuring the correct interpreter is used for running `upload_firmware.py`. [[1]](diffhunk://#diff-e6ffa5dc854b843b3ee3c3c28f8eae2f436c2df2b1ca299cca1fa5982e390cf8L87-R88) [[2]](diffhunk://#diff-e6ffa5dc854b843b3ee3c3c28f8eae2f436c2df2b1ca299cca1fa5982e390cf8L99-R100)